### PR TITLE
Release v1.1.0

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -1,18 +1,26 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
-MAINTAINER Leonid Makarov <leonid.makarov@blinkreaction.com>
+ENV VARNISH_VERSION 4.1
 
-RUN apk add --update --no-cache bash varnish && \
-	rm -rf /var/cache/apk/*
+RUN apk add --update --no-cache \
+	bash \
+	varnish \
+	&& rm -rf /var/cache/apk/*
 
 COPY default.vcl /opt/default.vcl
 COPY startup.sh /opt/startup.sh
 
 ENV VARNISH_PORT 80
+ENV VARNISH_ADMIN_PORT 6082
+ENV VARNISH_BACKEND_HOST web
 ENV VARNISH_BACKEND_PORT 80
 ENV VARNISH_CACHE_SIZE 64M
-ENV VARNISH_VARNISHLOG_PARAMS '-c -I RespStatus:^50'
+# See https://varnish-cache.org/docs/4.1/reference/varnishd.html
+ENV VARNISH_VARNISHD_PARAMS ''
+# See https://varnish-cache.org/docs/4.1/reference/varnishncsa.html
+ENV VARNISH_VARNISHNCSA_PARAMS ''
 
 EXPOSE 80
+EXPOSE 6082
 
 CMD ["/opt/startup.sh"]

--- a/4.1/startup.sh
+++ b/4.1/startup.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-# Delay start to avoid DNS lookup issues
-echo 'Waiting 5s before startup...'
-sleep 5
+set -e # Fail on errors
 
-echo 'Copying config from /opt/default.vcl...'
-cp -f /opt/default.vcl /etc/varnish/default.vcl
+custom_vcl="/var/www/.docksal/etc/varnish/default.vcl"
+if [[ -f "$custom_vcl" ]]; then
+	echo "Using custom VCL from $custom_vcl"
+	cp -f "$custom_vcl" /etc/varnish/default.vcl
+else
+	echo 'Using default VCL from /opt/default.vcl'
+	cp -f /opt/default.vcl /etc/varnish/default.vcl
+fi
 
 echo 'Evaluating config variables...'
 for name in VARNISH_BACKEND_PORT VARNISH_BACKEND_HOST VARNISH_BACKEND_DOMAIN

--- a/4.1/startup.sh
+++ b/4.1/startup.sh
@@ -15,7 +15,11 @@ do
 done
 
 echo 'Starting varnishd...'
-varnishd -f /etc/varnish/default.vcl -s malloc,${VARNISH_CACHE_SIZE} -a 0.0.0.0:${VARNISH_PORT} ${VARNISH_VARNISHD_PARAMS}
+varnishd -f /etc/varnish/default.vcl \
+	-s malloc,${VARNISH_CACHE_SIZE} \
+	-a :${VARNISH_PORT} \
+	-T :${VARNISH_ADMIN_PORT} \
+	${VARNISH_VARNISHD_PARAMS}
 
-echo 'Starting varnishlog...'
-varnishlog ${VARNISH_VARNISHLOG_PARAMS}
+echo 'Streaming logs (varnishncsa)...'
+varnishncsa ${VARNISH_VARNISHNCSA_PARAMS}

--- a/5.2/.dockerignore
+++ b/5.2/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.7
+
+ENV VARNISH_VERSION 5.2
+
+RUN apk add --update --no-cache \
+	bash \
+	varnish \
+	&& rm -rf /var/cache/apk/*
+
+COPY default.vcl /opt/default.vcl
+COPY startup.sh /opt/startup.sh
+
+ENV VARNISH_PORT 80
+ENV VARNISH_ADMIN_PORT 6082
+ENV VARNISH_BACKEND_HOST web
+ENV VARNISH_BACKEND_PORT 80
+ENV VARNISH_CACHE_SIZE 64M
+# See https://varnish-cache.org/docs/4.1/reference/varnishd.html
+ENV VARNISH_VARNISHD_PARAMS ''
+# See https://varnish-cache.org/docs/4.1/reference/varnishncsa.html
+ENV VARNISH_VARNISHNCSA_PARAMS ''
+
+EXPOSE 80
+EXPOSE 6082
+
+CMD ["/opt/startup.sh"]

--- a/5.2/default.vcl
+++ b/5.2/default.vcl
@@ -1,0 +1,173 @@
+# Based on https://fourkitchens.atlassian.net/wiki/display/TECH/Configure+Varnish+3+for+Drupal+7
+
+# This is a basic VCL configuration file for varnish.  See the vcl(7)
+# man page for details on VCL syntax and semantics.
+#
+
+# TODO: Update internal subnet ACL and security.
+
+# Define the internal network subnet.
+# These are used below to allow internal access to certain files while not
+# allowing access from the public internet.
+# acl internal {
+#  "192.10.0.0"/24;
+# }
+
+# Default backend definition.  Set this to point to your content
+# server.
+#
+vcl 4.0;
+
+import std;
+
+backend default {
+  .host = "{VARNISH_BACKEND_HOST}";
+  .port = "{VARNISH_BACKEND_PORT}";
+}
+
+# Respond to incoming requests.
+sub vcl_recv {
+  # Use anonymous, cached pages if all backends are down.
+  if (!std.healthy(req.backend_hint)) {
+    unset req.http.Cookie;
+  }
+
+  # Pipe these paths directly to Apache for streaming.
+  #if (req.url ~ "^/admin/content/backup_migrate/export") {
+  #  return (pipe);
+  #}
+
+  if (req.restarts == 0) {
+    if (req.http.x-forwarded-for) {
+      set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
+    }
+    else {
+      set req.http.X-Forwarded-For = client.ip;
+    }
+  }
+
+  # Do not cache these paths.
+  if (req.url ~ "^/status\.php$" ||
+      req.url ~ "^/update\.php$" ||
+      req.url ~ "^/admin$" ||
+      req.url ~ "^/admin/.*$" ||
+      req.url ~ "^/flag/.*$" ||
+      req.url ~ "^.*/ajax/.*$" ||
+      req.url ~ "^.*/ahah/.*$") {
+       return (pass);
+  }
+
+  # Do not allow outside access to cron.php or install.php.
+  #if (req.url ~ "^/(cron|install)\.php$" && !client.ip ~ internal) {
+    # Have Varnish throw the error directly.
+  #  error 404 "Page not found.";
+    # Use a custom error page that you've defined in Drupal at the path "404".
+    # set req.url = "/404";
+  #}
+
+  # Always cache the following file types for all users. This list of extensions
+  # appears twice, once here and again in vcl_fetch so make sure you edit both
+  # and keep them equal.
+  if (req.url ~ "(?i)\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js)(\?.*)?$") {
+    unset req.http.Cookie;
+  }
+
+  # Remove all cookies that Drupal doesn't need to know about. We explicitly
+  # list the ones that Drupal does need, the SESS and NO_CACHE. If, after
+  # running this code we find that either of these two cookies remains, we
+  # will pass as the page cannot be cached.
+  if (req.http.Cookie) {
+    # 1. Append a semi-colon to the front of the cookie string.
+    # 2. Remove all spaces that appear after semi-colons.
+    # 3. Match the cookies we want to keep, adding the space we removed
+    #    previously back. (\1) is first matching group in the regsuball.
+    # 4. Remove all other cookies, identifying them by the fact that they have
+    #    no space after the preceding semi-colon.
+    # 5. Remove all spaces and semi-colons from the beginning and end of the
+    #    cookie string.
+    set req.http.Cookie = ";" + req.http.Cookie;
+    set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
+    set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+    set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
+
+    if (req.http.Cookie == "") {
+      # If there are no remaining cookies, remove the cookie header. If there
+      # aren't any cookie headers, Varnish's default behavior will be to cache
+      # the page.
+      unset req.http.Cookie;
+    }
+    else {
+      # If there is any cookies left (a session or NO_CACHE cookie), do not
+      # cache the page. Pass it on to Apache directly.
+      return (pass);
+    }
+  }
+}
+
+# Set a header to track a cache HIT/MISS.
+sub vcl_deliver {
+  if (obj.hits > 0) {
+    set resp.http.X-Varnish-Cache = "HIT";
+  }
+  else {
+    set resp.http.X-Varnish-Cache = "MISS";
+  }
+}
+
+# Code determining what to do when serving items from the Apache servers.
+# beresp == Back-end response from the web server.
+sub vcl_backend_response {
+  # We need this to cache 404s, 301s, 500s. Otherwise, depending on backend but
+  # definitely in Drupal's case these responses are not cacheable by default.
+  if (beresp.status == 404 || beresp.status == 301 || beresp.status == 500) {
+    set beresp.ttl = 10m;
+  }
+
+  # Don't allow static files to set cookies.
+  # (?i) denotes case insensitive in PCRE (perl compatible regular expressions).
+  # This list of extensions appears twice, once here and again in vcl_recv so
+  # make sure you edit both and keep them equal.
+  if (bereq.url ~ "(?i)\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js)(\?.*)?$") {
+    unset beresp.http.set-cookie;
+  }
+
+  # Allow items to be stale if needed.
+  set beresp.grace = 6h;
+
+  # Disable buffering only for BigPipe responses
+  if (beresp.http.Surrogate-Control ~ "BigPipe/1.0") {
+    set beresp.do_stream = true;
+    set beresp.ttl = 0s;
+  }
+
+}
+
+# In the event of an error, show friendlier messages.
+sub vcl_synth {
+
+  # Otherwise redirect to the homepage, which will likely be in the cache.
+  set resp.http.Content-Type = "text/html; charset=utf-8";
+  synthetic( {"
+<html>
+<head>
+  <title>Page Unavailable</title>
+  <style>
+    body { background: #303030; text-align: center; color: white; }
+    #page { border: 1px solid #CCC; width: 500px; margin: 100px auto 0; padding: 30px; background: #323232; }
+    a, a:link, a:visited { color: #CCC; }
+    .error { color: #222; }
+  </style>
+</head>
+<body onload="setTimeout(function() { window.location = '/' }, 5000)">
+  <div id="page">
+    <h1 class="title">Page Unavailable</h1>
+    <p>The page you requested is temporarily unavailable.</p>
+    <p>We're redirecting you to the <a href="/">homepage</a> in 5 seconds.</p>
+    <div class="error">(Error "} + resp.status + " " + resp.reason + {")</div>
+  </div>
+</body>
+</html>
+"} );
+  return (deliver);
+}

--- a/5.2/startup.sh
+++ b/5.2/startup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Delay start to avoid DNS lookup issues
+echo 'Waiting 5s before startup...'
+sleep 5
+
+echo 'Copying config from /opt/default.vcl...'
+cp -f /opt/default.vcl /etc/varnish/default.vcl
+
+echo 'Evaluating config variables...'
+for name in VARNISH_BACKEND_PORT VARNISH_BACKEND_HOST VARNISH_BACKEND_DOMAIN
+do
+    eval value=\$$name
+    sed -i "s|{${name}}|${value}|g" /etc/varnish/default.vcl
+done
+
+echo 'Starting varnishd...'
+varnishd -f /etc/varnish/default.vcl \
+	-s malloc,${VARNISH_CACHE_SIZE} \
+	-a :${VARNISH_PORT} \
+	-T :${VARNISH_ADMIN_PORT} \
+	${VARNISH_VARNISHD_PARAMS}
+
+echo 'Streaming logs (varnishncsa)...'
+varnishncsa ${VARNISH_VARNISHNCSA_PARAMS}

--- a/5.2/startup.sh
+++ b/5.2/startup.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-# Delay start to avoid DNS lookup issues
-echo 'Waiting 5s before startup...'
-sleep 5
+set -e # Fail on errors
 
-echo 'Copying config from /opt/default.vcl...'
-cp -f /opt/default.vcl /etc/varnish/default.vcl
+custom_vcl="/var/www/.docksal/etc/varnish/default.vcl"
+if [[ -f "$custom_vcl" ]]; then
+	echo "Using custom VCL from $custom_vcl"
+	cp -f "$custom_vcl" /etc/varnish/default.vcl
+else
+	echo 'Using default VCL from /opt/default.vcl'
+	cp -f /opt/default.vcl /etc/varnish/default.vcl
+fi
 
 echo 'Evaluating config variables...'
 for name in VARNISH_BACKEND_PORT VARNISH_BACKEND_HOST VARNISH_BACKEND_DOMAIN

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2017 Docksal
+Copyright (c) 2016-2018 Docksal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
 # Varnish Docker images for Docksal
 
-- Varnish 3
-- Varnish 4
+- Varnish 3.0 (deprecated and unsupported)
+- Varnish 4.1
+- Varnish 5.2
 
 This image(s) is part of the [Docksal](http://docksal.io) image library.
+
+
+## Features
+
+The following feature were added on top of the Fourkitchens config:
+
+- BigPipe support
 
 
 ## Environmental variables
 
 - `VARNISH_PORT` - port Varnish binds to, default: `80`
-- `VARNISH_BACKEND_HOST` - **must set this** to the web container IP/hostname
-- `VARNISH_BACKEND_PORT` - web container port, default: `80`
+- `VARNISH_BACKEND_HOST` - backed-end IP/host, default: `web`
+- `VARNISH_BACKEND_PORT` - backed-end port, default: `80`
 - `VARNISH_CACHE_SIZE` - cache size, default: `64M`
-- `VARNISH_VARNISHD_PARAMS` - extra parameters for `varnishd`
-- `VARNISH_VARNISHLOG_PARAMS` - parameters for `varnishlog`, default: `-c -m TxStatus:^50` (Log failing (client side) requests)
+- `VARNISH_VARNISHD_PARAMS` - extra parameters for `varnishd`.
+- `VARNISH_VARNISHNCSA_PARAMS` - parameters for `varnishncsa` (logging).
 
 
 ## VCL
@@ -22,11 +30,7 @@ The default VCL is based on:
 
 https://fourkitchens.atlassian.net/wiki/display/TECH/Configure+Varnish+3+for+Drupal+7
 
-To provide a custom vcl config mount it at `/opt/default.vcl`.
+To provide a custom VCL config mount it at `/opt/default.vcl`.
 
-
-## Features
-
-The following feature were added on top of the Fourkitchens config:
-
-- BigPipe support
+When used with Docksal, custom VCL is automatically loaded from `.docksal/etc/varnish/default.vcl` if one exists 
+in the project codebase.


### PR DESCRIPTION
- Expose admin port `6082` by default. Overridable via `VARNISH_ADMIN_PORT`
- Set `VARNISH_BACKEND_HOST=web` by default
- Switched from `varnishlog` to `varnishncsa` for more meaningful logs (Apache format)
- Switched to alpine:3.6 for Varnish 4.1
- Added Varnish 5.2
- Custom configuration support via `/var/www/.docksal/etc/varnish/default.vcl`