### PR TITLE
Give users the ability to set the secret

### DIFF
--- a/3.0/startup.sh
+++ b/3.0/startup.sh
@@ -14,6 +14,11 @@ do
     sed -i "s|{${name}}|${value}|g" /etc/varnish/default.vcl
 done
 
+if [[ -n "${VARNISH_SECRET}" ]]; then
+    echo "${VARNISH_SECRET}" > /etc/varnish/secret
+    VARNISH_VARNISHD_PARAMS="${VARNISH_VARNISHD_PARAMS} -S /etc/varnish/secret"
+fi
+
 echo 'Starting varnishd...'
 varnishd -f /etc/varnish/default.vcl -s malloc,${VARNISH_CACHE_SIZE} -a 0.0.0.0:${VARNISH_PORT} ${VARNISH_VARNISHD_PARAMS}
 

--- a/4.1/startup.sh
+++ b/4.1/startup.sh
@@ -18,6 +18,11 @@ do
     sed -i "s|{${name}}|${value}|g" /etc/varnish/default.vcl
 done
 
+if [[ -n "${VARNISH_SECRET}" ]]; then
+    echo "${VARNISH_SECRET}" > /etc/varnish/secret
+    VARNISH_VARNISHD_PARAMS="${VARNISH_VARNISHD_PARAMS} -S /etc/varnish/secret"
+fi
+
 echo 'Starting varnishd...'
 varnishd -f /etc/varnish/default.vcl \
 	-s malloc,${VARNISH_CACHE_SIZE} \

--- a/5.2/startup.sh
+++ b/5.2/startup.sh
@@ -18,6 +18,11 @@ do
     sed -i "s|{${name}}|${value}|g" /etc/varnish/default.vcl
 done
 
+if [[ -n "${VARNISH_SECRET}" ]]; then
+    echo "${VARNISH_SECRET}" > /etc/varnish/secret
+    VARNISH_VARNISHD_PARAMS="${VARNISH_VARNISHD_PARAMS} -S /etc/varnish/secret"
+fi
+
 echo 'Starting varnishd...'
 varnishd -f /etc/varnish/default.vcl \
 	-s malloc,${VARNISH_CACHE_SIZE} \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following feature were added on top of the Fourkitchens config:
 - `VARNISH_CACHE_SIZE` - cache size, default: `64M`
 - `VARNISH_VARNISHD_PARAMS` - extra parameters for `varnishd`.
 - `VARNISH_VARNISHNCSA_PARAMS` - parameters for `varnishncsa` (logging).
+- `VARNISH_SECRET` - allow the secret to be set for varnish.
 
 
 ## VCL


### PR DESCRIPTION
In the Drupal 7 varnish module it requires that for version 4 you have the ability to set the secret (it's required) and the set up for creating a secret right now is too laborious and confusing for someone who may not know how to.