### PR TITLE
Release 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ env:
     - REPO=docksal/varnish
 
   matrix:
-    - VERSION=4.1 TAGS=4.1
     - VERSION=6.0 TAGS=6.0
-    - VERSION=6.1 TAGS=6.1,latest
+    - VERSION=6.2 TAGS=6.2,latest
 
 install:
   # Install Docksal to have a matching versions of Docker on the build host

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION=${VERSION}
 ARG GOMPLATE_VERSION=3.0.0
 RUN set -x && \
 	apt-get update && \
-	apt-get install -y --no-install-recommends curl && \
+	apt-get install -y --no-install-recommends curl net-tools && \
 	rm -rf /var/lib/apt/lists/* && \
 	curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim && \
 	chmod 755 /usr/local/bin/gomplate

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER ?= docker
 
-VERSION ?= 6.1
+VERSION ?= 6.2
 TAG ?= $(VERSION)
 
 REPO ?= docksal/varnish

--- a/bin/varnishd.sh
+++ b/bin/varnishd.sh
@@ -2,6 +2,7 @@
 
 echo 'Starting varnishd...'
 exec varnishd \
+	-F \
 	-f /etc/varnish/default.vcl \
 	-s malloc,${VARNISH_CACHE_SIZE} \
 	-a :${VARNISH_PORT} \

--- a/conf/default.vcl.tmpl
+++ b/conf/default.vcl.tmpl
@@ -172,3 +172,10 @@ sub vcl_synth {
 "} );
   return (deliver);
 }
+
+# Cache HTTP and HTTPS separate.
+sub vcl_hash {
+  if (req.http.X-Forwarded-Proto) {
+    hash_data(req.http.X-Forwarded-Proto);
+  }
+}


### PR DESCRIPTION
- Switched to the [official Varnish Docker images](https://hub.docker.com/_/varnish)
  - Removed Varnish 4.1 (EOL) and Varnish 6.0 (EOL)
  - Added Varnish 6.2 and 6.3
- Cache HTTP/HTTPS requests separately (#33)
