### PR TITLE
Make compatible for M1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION
 ENV VERSION=${VERSION}
 
 # Install aditional dependencies
-ARG GOMPLATE_VERSION=3.0.0
+ARG GOMPLATE_VERSION=3.10.0
 RUN set -x && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends curl net-tools && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER ?= docker
 
-VERSION ?= 6.2
+VERSION ?= 7.0
 TAG ?= $(VERSION)
 
 REPO ?= docksal/varnish


### PR DESCRIPTION
#41 
updating the version from GOMPLATE to 3.10.0. Using this with varnish 7.0 will make it compatible for arm64